### PR TITLE
added logic for redirecting to login in page

### DIFF
--- a/src/components/HeroPostNoteBtn.jsx
+++ b/src/components/HeroPostNoteBtn.jsx
@@ -1,9 +1,14 @@
-import { NavLink, useOutletContext } from 'react-router-dom';
+import { NavLink, useNavigate, useOutletContext } from 'react-router-dom';
 import { useAuth } from '../hooks/use-auth';
 
 const HeroPostNoteBtn = () => {
     const { auth } = useAuth();
+    const navigate = useNavigate();
+
     const handleRedirect = useOutletContext()
+    // const redirectToLogin = () => {
+    //     navigate('/login', { state: { from: '/newnote' } });
+    // };
 
     return (
         <section className='flex flex-col items-center space-y-6 md:mx-0 md:border-t-[1px] border-purple-dark/80 pt-6 lg:w-11/12'>

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/use-auth.js';
+
 import z from 'zod';
+
 import postLogin from '../api/post/post-login.js';
 import login from '/note-icons/login.png';
 import toast from 'react-hot-toast';
@@ -12,8 +14,12 @@ const loginSchema = z.object({
 });
 
 function LoginForm() {
-    const { auth, setAuth } = useAuth();
+    const { setAuth } = useAuth();
+
     const navigate = useNavigate();
+    const location = useLocation();
+    // if user is on log in page because they clicked post note
+    const from = location.state?.from || '/';
 
     const [credentials, setCredentials] = useState({
         username: '',
@@ -53,7 +59,7 @@ function LoginForm() {
                     firstName: response.first_name,
                 });
                 toast(`Welcome back ${response.first_name}!`);
-                navigate('/');
+                navigate(from);
             } catch (error) {
                 toast(error.message);
             }
@@ -108,7 +114,7 @@ function LoginForm() {
             {/* Notice */}
             <p className='font-main font-light text-xl italic md:text-2xl'>
                 Don't have an account yet?
-                <Link className='font-medium not-italic ml-2' to='/signup'>
+                <Link className='font-medium not-italic ml-2' to='/signup' state={{from}}>
                     {' '}
                     Sign up!
                 </Link>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -43,7 +43,7 @@ const Nav = () => {
         toast('Please log in to Post-A-Note!');
         setTimeout(() => {
             setShowNav(false);
-            navigate('/login');
+            navigate('/login', { state: { from: '/newnote' } });
         }, 1200);
     };
 

--- a/src/components/SignupForm.jsx
+++ b/src/components/SignupForm.jsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/use-auth.js';
+
 import z from 'zod';
+
 import postSignup from '../api/post/post-signup.js';
 import signup from '/note-icons/signup.png';
 import toast from 'react-hot-toast';
 import postLogin from '../api/post/post-login.js';
-import { useAuth } from '../hooks/use-auth.js';
 
 const signupSchema = z.object({
     firstName: z.string().min(1, 'Enter your first name'),
@@ -16,8 +18,11 @@ const signupSchema = z.object({
 });
 
 function SignupForm() {
-    const { auth, setAuth } = useAuth();
+    const { setAuth } = useAuth();
+
     const navigate = useNavigate();
+    const location = useLocation();
+    const from = location.state?.from || '/';
 
     const [credentials, setCredentials] = useState({
         firstName: '',
@@ -68,7 +73,7 @@ function SignupForm() {
                 firstName: loginResponse.first_name,
             });
             toast(`Welcome ${loginResponse.first_name}!`);
-            navigate('/');
+            navigate(from);
         } catch (error) {
             toast(error.message);
         }


### PR DESCRIPTION
- situation: user clicks post-a-note button from desktop nav, mobile nav or about section but they aren’t logged in
- they get redirected to the log in page
- once they’ve logged in successfully, i added functions to preserve their path to the post-a-note page
- continued this logic/work into the sign up page as well