### PR TITLE
Link to new serializers

### DIFF
--- a/src/api/get/get-active-workshops.js
+++ b/src/api/get/get-active-workshops.js
@@ -1,0 +1,21 @@
+async function getActiveWorkshops() {
+    const url = `${import.meta.env.VITE_API_URL}/activeworkshops/`;
+
+    const response = await fetch(url, { method: 'GET' });
+
+    if (!response.ok) {
+        const fallbackError =
+            'Oops! Looks like we are having issues with workshops right now';
+
+        const data = await response.json().catch(() => {
+            throw new Error(fallbackError);
+        });
+
+        const errorMsg = data?.detail ?? fallbackError;
+        throw new Error(errorMsg);
+    }
+
+    return await response.json();
+}
+
+export default getActiveWorkshops;

--- a/src/api/get/get-recent-notes.js
+++ b/src/api/get/get-recent-notes.js
@@ -1,0 +1,21 @@
+async function getRecentNotes() {
+    const url = `${import.meta.env.VITE_API_URL}/recentnotes/`;
+
+    const response = await fetch(url, { method: 'GET' });
+
+    if (!response.ok) {
+        const fallbackError =
+            'Oops! Looks like we are having issues with notes right now';
+
+        const data = await response.json().catch(() => {
+            throw new Error(fallbackError);
+        });
+
+        const errorMsg = data?.detail ?? fallbackError;
+        throw new Error(errorMsg);
+    }
+
+    return await response.json();
+}
+
+export default getRecentNotes;

--- a/src/components/HeroBanner.jsx
+++ b/src/components/HeroBanner.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import useNotes from '../hooks/use-notes';
+import useRecentNotes from '../hooks/use-recent-notes';
 import Loader from './Loader';
 import Error from './Error';
 
 const HeroBanner = () => {
-    const { notes, isLoading, error } = useNotes();
+    const { notes, isLoading, error } = useRecentNotes();
     const [index, setIndex] = useState(0);
     const intervalRef = useRef(null);
 

--- a/src/hooks/use-active-workshops.js
+++ b/src/hooks/use-active-workshops.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import getActiveWorkshops from "../api/get/get-active-workshops";
+
+export default function useWorkshops() {
+    const [workshops, setWorkshops] = useState([])
+    const [isLoading, setIsLoading] = useState(true)
+    const [error, setError] = useState()
+
+    useEffect(() => {
+        getActiveWorkshops()
+        .then((workshops) => {
+            setWorkshops(workshops)
+            setIsLoading(false)
+        })
+        .catch((error) => {
+            setError(error)
+            setIsLoading(false)
+        })
+    }, [])
+
+    return {workshops, setWorkshops, isLoading, error}
+}

--- a/src/hooks/use-recent-notes.js
+++ b/src/hooks/use-recent-notes.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import getRecentNotes from '../api/get/get-recent-notes';
+
+export default function useRecentNotes() {
+    const [notes, setNotes] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState();
+
+    useEffect(() => {
+        getRecentNotes()
+            .then((notes) => {
+                setNotes(notes);
+                setIsLoading(false);
+            })
+            .catch((error) => {
+                setError(error);
+                setIsLoading(false);
+            });
+    }, []);
+
+    return { notes, isLoading, error };
+}


### PR DESCRIPTION
add apis for activeworkshops and recentnotes, (get-active-workshops) (get-recent-notes)
create hooks (use-active-workshops) (use-recent-notes)
switch hero banner to point to use-recent-notes (useRecentNotes)